### PR TITLE
Fix/install webrick and csv gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+gem 'webrick'
+gem 'csv'
 
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     commonmarker (0.23.10)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    csv (3.3.0)
     dnsruby (1.72.1)
       simpleidn (~> 0.2.1)
     drb (2.2.1)
@@ -259,17 +260,20 @@ GEM
     unf_ext (0.0.9.1)
     unicode-display_width (1.8.0)
     uri (0.13.0)
+    webrick (1.8.1)
 
 PLATFORMS
   x86_64-darwin
 
 DEPENDENCIES
+  csv
   github-pages (~> 231)
   http_parser.rb (~> 0.6.0)
   jekyll-feed (~> 0.12)
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick
 
 BUNDLED WITH
    2.5.10


### PR DESCRIPTION
When I tried to execute `bundle exec jekyll serve` I got the following error:

<img width="1590" alt="image" src="https://github.com/abuzzany/abuzzany.github.io/assets/4792866/15c6ee5d-d633-417d-ad02-46bd624305bc">

After a supe exhaustive research on google (I asked to ChatGpt jaja), I realized that there were some missing dependencies.
